### PR TITLE
Ajuste a query de productos excedidos y agotados

### DIFF
--- a/app/Http/Controllers/QueriesController.php
+++ b/app/Http/Controllers/QueriesController.php
@@ -70,7 +70,7 @@ class QueriesController extends Controller
         $productos = DB::table('productos')
             ->select('id', 'nombre', 'stock', 'stockMinimo')
             //->where('estado', '=', 1)
-            ->where('stockMinimo', '>=', DB::raw('stock'))
+            ->where('stockMinimo', '>', DB::raw('stock'))
             ->orderBy('estado', 'desc')
             ->limit(5)
             ->get();
@@ -103,7 +103,7 @@ class QueriesController extends Controller
         $productos = DB::table('productos')
             ->select('id', 'nombre', 'stock', 'stockMaximo')
             ->where('estado', '=', 1)
-            ->where('stockMaximo', '<=', DB::raw('stock'))
+            ->where('stockMaximo', '<', DB::raw('stock'))
             ->where('estado', '=', 1)
             ->limit(5)
             ->get();


### PR DESCRIPTION
This pull request includes changes to the `QueriesController.php` file to adjust the conditions for retrieving products based on their stock levels. The most important changes are:

* [`app/Http/Controllers/QueriesController.php`](diffhunk://#diff-0a780a120e2219fbd95584d2332ac99288184f64da7d1d106e3f23904479affcL73-R73): Modified the `getProductosStockMinimo` method to change the comparison operator from `>=` to `>` when filtering products by their minimum stock level.
* [`app/Http/Controllers/QueriesController.php`](diffhunk://#diff-0a780a120e2219fbd95584d2332ac99288184f64da7d1d106e3f23904479affcL106-R106): Modified the `getProductosOverstock` method to change the comparison operator from `<=` to `<` when filtering products by their maximum stock level.